### PR TITLE
Some type improvements

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -45,6 +45,12 @@ interface IGenericObjectIndexSignature {
   [key: string]: any;
 }
 
+export type CustomConfiguration = Omit<IConfigurationInternal, 'accessToken'>;
+type SerializedObject<T extends object> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types -- any function can be expected here
+  [key in keyof T]: T[key] extends Function | RegExp ? string : T[key];
+};
+
 interface IPayload {
   access_token: string;
   data: {
@@ -66,9 +72,9 @@ interface IPayload {
       reportingMethod: 'fetch' | 'sendBeacon';
       actionHistory?: string;
       applicationState?: string;
-      configuration?: Omit<IConfigurationInternal, 'accessToken'>;
+      configuration?: SerializedObject<CustomConfiguration>;
       locationInfo?: object;
-      [key: string]: any;
+      [key: string]: unknown;
     };
     environment: string;
     framework: string | false;


### PR DESCRIPTION
**Changes:**

Some minor type improvements as we discussed.

Now `buildObjectDeepSorted` conserves the type of what's coming in to what comes out of it and the serialization of the custom configuration also happens a bit more safely in regards to type.
They involve a few casts I am not sure whether we could get away without, at least I don't know how we would do so personally ^^